### PR TITLE
Conditionally add `person-description` div

### DIFF
--- a/people/index.html
+++ b/people/index.html
@@ -77,7 +77,9 @@ markers = new L.featureGroup();
         <a class="social" href="http://github.com/{{ person.github }}"><i class="fa fa-github"></i> {{ person.github }}</a>
         {% endif %}
       </div>
+      {% if person.content %}
       <div class="person-description">{{ person.content }}</div>
+      {% endif %}
       <div class="cf"></div>
     </li>
   {% endfor %}


### PR DESCRIPTION
Avoid those pesky empty description boxes from appearing when hovering over a user without said description.
