### PR TITLE
Hacky way to avoid empty descriptions

### DIFF
--- a/people/index.html
+++ b/people/index.html
@@ -77,7 +77,7 @@ markers = new L.featureGroup();
         <a class="social" href="http://github.com/{{ person.github }}"><i class="fa fa-github"></i> {{ person.github }}</a>
         {% endif %}
       </div>
-      {% if person.content %}
+      {% if person.content.size > 1 %}
       <div class="person-description">{{ person.content }}</div>
       {% endif %}
       <div class="cf"></div>


### PR DESCRIPTION
Unfortunately, the `person.content` always seems to contain a `\n` linebreak.  You can't use any filters in conditional blocks (such as `strip_newline`) and `if person.content != blank` doesn't seem to act as expected.
