### PR TITLE
bump up the Google group mention

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ extra_js:
 
 We're a group of developers, GIS specialists, designers, and geographers all gathering under one roof in the name of maps. CUGOS is the official Cascadia chapter of OSGeo. We are active in the spatial community because we believe in the power maps and data hold, and enjoy exploring their interaction from every perspective.
 
-We [meet regularly](/meetings) on the third wednesday of every month and irregularly on Thursdays at different locations. If you're interested in participating in our community, please send a message to <em>hello@cugos.org</em>. CUGOS has its own IRC channel hosted on [Freenode](https://freenode.net/). You can connect to our channel <strong>#cugos</strong>. If you're new to IRC, there's a [neat web client](http://webchat.freenode.net/) so you don't have to download any software.
+We [meet regularly](/meetings) on the third wednesday of every month and irregularly on Thursdays at different locations. If you're interested in participating in our community, join the [Google group](https://groups.google.com/forum/#!forum/cugos) and please send a message to <em>hello@cugos.org</em>. CUGOS has its own IRC channel hosted on [Freenode](https://freenode.net/). You can connect to our channel <strong>#cugos</strong>. If you're new to IRC, there's a [neat web client](http://webchat.freenode.net/) so you don't have to download any software.
 
 ![working and cugosing](/image/springfling2015-homepage.jpg)
 


### PR DESCRIPTION
currently joining the Google group is not mentioned until the
end of the index page. Often times people send a message to
hello@cugos.org just to say they'd like to participate in the group. thought
it would be nice to explicitly mention that if they're interested in
participating they should join the Google group AND also say hi at
hello@cugos.org.
