### PR TITLE
code of conduct

### DIFF
--- a/2016-spring-fling/index.md
+++ b/2016-spring-fling/index.md
@@ -239,6 +239,8 @@ speakers:
 
 The CUGOS Spring Fling is a **full day event centered around open source geo**. This is an intensely educational session for practitioners of all things open-source geospatial. If you care about geometry busting workflows, brain dumping academic research, parsing vertices while flying drones, code as well as content, usability through design, then show up and eat free food! Join us for this special all-day-kinda event at the magical University of Washington in Seattle.
 
+Our number one goal is to make the Spring Fling a welcoming event for everybody. Please take a moment to read over the [CUGOS code of conduct](/code-of-conduct).
+
 **Location**: The fling will be hosted at the University of Washington, Forest Club Room 207 in Anderson Hall. It's the room with the elk in it. [[campus map](http://uw.edu/maps/?and)]
 
 **Sponsors**: Want to support this event? Email [hello@cugos.org](mailto:hello@cugos.org) for information about how to get involved.

--- a/about/index.md
+++ b/about/index.md
@@ -7,11 +7,13 @@ permalink:
 
 About
 =====
-The Cascadia chapter of the OSGeo is based on a regional FOSS GIS user group formed in 2007 called Cascadia Users of Geospatial Open Source (CUGOS). We are an active group of members who are passionate about open source software, GIS, and our region. We have members from all walks of life, a large spectrum of business and academia, and active OSGeo members (board members, charter members, and active project participants).
+The Cascadia chapter of the OSGeo is based on a regional FOSS GIS user group formed in 2007 called Cascadia Users of Geospatial Open Source (CUGOS). We are an active group of members who are passionate about open source software, GIS, and our region. We have members from all walks of life, a large spectrum of business and academia, and active OSGeo members (board members, charter members, and active project participants). 
 
 Mission
 =======
 The OSGeo Cascadia Chapter strives to provide support for local users of Open Source Geospatial software, and to promote the goals and projects of the Open Source Geospatial Foundation. The Chapter is focused on the Pacific Northwest region of the United States as well as Southern British Columbia. The group hosts meetings providing networking, support and educational opportunities to the local members. 
+
+Take a look at our [code of conduct](/code-of-conduct)
 
 History
 =======

--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -1,0 +1,66 @@
+---
+layout: default
+title: Code of Conduct
+---
+
+# CUGOS Code of Conduct
+
+This code of conduct governs how we behave in any CUGOS forum or event and whenever we will be judged by our actions. We expect it to be honored by everyone who participates in the CUGOS community formally or informally, or claims any affiliation with the CUGOS.
+
+It applies to in-person events (such as conferences and related social events), IRC, public and private mailing lists, github issues, Twitter, and any other forums which the community uses for communication and interactions.
+
+This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter, so that it can enrich all of us and the technical communities in which we participate.
+
+## Diversity Statement
+
+CUGOS welcomes and encourages participation by everyone. We are committed to being a community that everyone feels good about joining, and we will always work to treat everyone well. No matter how you identify yourself or how others perceive you: we welcome you.
+
+## Specific Guidelines
+
+We strive to:
+
+**Be open**   
+We invite anyone to participate in our community. We preferably use public methods of communication for project-related messages, unless discussing something sensitive. This applies to messages for help or project-related support, too; not only is a public support request much more likely to result in an answer to a question, it also makes sure that any inadvertent mistakes made by people answering will be more easily detected and corrected.
+
+**Be empathetic, welcoming, friendly, and patient.**   
+We work together to resolve conflict, assume good intentions, and do our best to act in an empathetic fashion. We may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. Note that we have a multi-cultural, multi-lingual community and some of us are non-native speakers. We should be respectful when dealing with other community members as well as with people outside our community.
+
+**Be collaborative.**   
+Our work will be used by other people, and in turn we will depend on the work of others. When we make something for the benefit of CUGOS, we are willing to explain to others how it works, so that they can build on the work to make it even better. Any decision we make will affect users and colleagues, and we take those consequences seriously when making decisions.
+
+**Be inquisitive.**   
+Nobody knows everything! Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful, within the context of our shared goal of improving CUGOS.
+
+**Be careful in the words that we choose.**   
+Whether we are participating as professionals or volunteers, we value professionalism in all interactions, and take responsibility for our own speech. Be kind to others. Do not insult or put down other participants.
+
+**Be concise**   
+Keep in mind that what you write once will be read by hundreds of persons. Writing a short email means people can understand the conversation as efficiently as possible. Short emails should always strive to be empathetic, welcoming, friendly and patient. When a long explanation is necessary, consider adding a summary.
+
+Try to bring new ideas to a conversation so that each mail adds something unique to the thread, keeping in mind that the rest of the thread still contains the other messages with arguments that have already been made.
+
+Try to stay on topic, especially in discussions that are already fairly large.
+
+**Step down considerately.**   
+Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off. In doing so, they should remain respectful of those who continue to participate in the project and should not misrepresent the project's goals or achievements. Likewise, community members should respect any individual's choice to leave the project.
+
+## Anti-Harassment
+
+Harassment and other exclusionary behaviour are not acceptable. This includes, but is not limited to:
+
+* Personal insults or discriminatory jokes and language, especially those using racist or sexist terms.
+* Offensive comments, excessive or unnecessary profanity.
+* Intimidation, violent threats or demands.
+* Sustained disruption of sessions or events.
+* Stalking, harassing photography or recording.
+* Unwelcome physical contact or sexual attention.
+* Repeated harassment of others. In general, if someone asks you to stop, then stop.
+* Posting (or threatening to post) other people's personally identifying information ("doxing").
+* Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history.
+* Advocating for, or encouraging, any of the above behaviour.
+
+## Reporting Guidelines
+
+If you believe someone is breaking this code of conduct, you may reply to them, and point to this code of conduct. Such messages may be in public or in private, whatever is most appropriate. Assume good faith; it is more likely that participants are unaware of their bad behaviour than that they intentionally try to degrade the quality of the discussion. Should there be difficulties in dealing with the situation, you may report your concerns to event staff, a forum leader or the CUGOS organizers. Serious or persistent offenders may be expelled from the event or forum by event organizers or forum leaders.
+
+*This code is drafted from the [OSGeo Code of Conduct](http://www.osgeo.org/code_of_conduct).*

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -40,7 +40,7 @@ h6 {
   font-weight: 600;
 }
 a { text-decoration:none; }
-p { font-weight:100; }
+p, li { font-weight:100; }
 strong { font-weight:900; }
 
 .copyright {


### PR DESCRIPTION
Forking the OSGeo code of conduct for CUGOS. This can be found at `cugos.org/code-of-conduct` and is prominently linked to from the `/about` page and `/2016-spring-fling` page.

cc @aaronr @powersa 