### PR TITLE
update URL structure, add meeting notes

### DIFF
--- a/404.html
+++ b/404.html
@@ -23,20 +23,27 @@
       li { display: table-cell; font-weight: bold; width: 1%; }
       .divider { border-top: 1px solid #d5d5d5; border-bottom: 1px solid #fafafa;}
 
-
     </style>
   </head>
   <body>
 
-    <div class="container">
 
-      <center><img src="/image/base/cugos_404.png"></center>
-      <h1>404</h1>
-      <p><strong>There isn't a CUGOS Page here.</strong></p>
-      <p>
-        <a href="http://cugos.org/">Head back to cugos.org</a>
-      </p>
 
-    </div>
+    <script>
+    if (window.location.search !== '?ref=404redirect') {
+      var url = window.location.pathname;
+      var items = url.split('/');
+      console.log(items);
+      window.location = '/' + items[1] + '/' + items[2] + '-' + items[3] + '-' + items[4] + '/?ref=404redirect';
+    } else {
+      document.body.innerHTML = '<div class="container">\
+        <center><img src="/image/base/cugos_404.png"></center>\
+        <h1>404</h1>\
+        <p><strong>There isn\'t a CUGOS Page here.</strong></p>\
+        <p><a href="http://cugos.org/">Head back to cugos.org</a></p>\
+        </div>';
+    }
+    </script>
+
   </body>
 </html>

--- a/_config.yml
+++ b/_config.yml
@@ -6,4 +6,4 @@ url: http://cugos.org/
 future: true
 markdown: kramdown
 highlighter: rouge
-permalink: pretty
+permalink: /:categories/:year-:month-:day/

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -1,0 +1,12 @@
+---
+layout: page
+---
+
+{{content}}
+
+<h2>Board meeting notes</h2>
+<ul>
+{% for post in site.categories.notes %}
+  <li><a href="{{post.url}}">{{post.date | date_to_string}}</a></li>
+{% endfor %}
+</ul>

--- a/_layouts/notes.html
+++ b/_layouts/notes.html
@@ -1,0 +1,37 @@
+---
+layout: default
+---
+
+<div class="content cf">
+
+  <div class="content-main">
+    <h1>Board Meeting - {{ page.date | date_to_string }}</h1>
+    <p style="background: white; padding: 1em;"><small><strong>Attendees</strong>: {{page.attendees}}<br>
+       <strong>Location</strong>: {{page.location}}<br>
+       <strong>Time</strong>: {{page.time}}</small></p>
+    {{ content }}
+  </div>
+
+  <div class="content-side">
+    <div class="side-info next-meeting">
+      {% for meeting in site.categories.meetings limit: 1  %}
+        <a href={{ meeting.url }}>Next CUGOS meeting: {{ meeting.title }}</a>
+      {% endfor %}
+    </div>
+
+    <div class="side-info">
+      <h2>Code of Conduct</h2>
+      <p>CUGOS strives to be an inclusive community for anyone interested in open source geography. Before attending our meetings, please familiarize yourself with our <a href="/code-of-conduct/">Code of Conduct</a>.
+    </div>
+
+    <div class="side-info">
+      <h2>About CUGOS</h2>
+      <p><a href="/about/">Learn more</a> about CUGOS, our mission, and our annual reports.</p>
+    </div>
+    <div class="side-info">
+      <p>Want to stay up to date with CUGOS news? <a href="https://groups.google.com/forum/#!forum/cugos" target="_blank">Join our Google Group</a>.</p>
+      <p><small>You'll have to request access, we'll approve you ASAP.</small></p>
+    </div>
+  </div>
+
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,11 +5,8 @@ layout: default
 <div class="content cf">
 
   <div class="content-main">
-    <h2>{{ page.title }}</h2>
-    <hr>
-    <span class="date">{{ page.date | date_to_string }}</span><br>
-    <span class="category">Category: {{ page.categories | category_links }}</span>
-    <hr>
+    <h1>{{ page.title }}</h1>
+    <p><small>{{ page.date | date_to_string }}</small></p>
     {{ content }}
   </div>
 

--- a/about/index.md
+++ b/about/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: about
 title: About
 weight: 7
 sidebar:
@@ -12,7 +12,7 @@ About
 =====
 CUGOS is organized as an IRS 501(c)(6), not for profit, state wide professional association of Open Source GIS professionals.
 
-Cascadia Users of Geospatial Open Source (CUGOS) was formed in 2007. CUGOS acts as the [Cascadia Chapter](http://wiki.osgeo.org/wiki/Cascadia) of the [OSGeo Foundation](http://www.osgeo.org/).  We are an active group of members who are passionate about open source software, GIS, and our region. We have members from all walks of life, a large spectrum of business and academia, and active OSGeo members (board members, charter members, and active project participants). 
+Cascadia Users of Geospatial Open Source (CUGOS) was formed in 2007. CUGOS acts as the [Cascadia Chapter](http://wiki.osgeo.org/wiki/Cascadia) of the [OSGeo Foundation](http://www.osgeo.org/).  We are an active group of members who are passionate about open source software, GIS, and our region. We have members from all walks of life, a large spectrum of business and academia, and active OSGeo members (board members, charter members, and active project participants).
 
 Mission
 =======

--- a/notes/_posts/2017-01-11-notes.md
+++ b/notes/_posts/2017-01-11-notes.md
@@ -1,0 +1,67 @@
+---
+layout: notes
+attendees: 'Sam Matthews, Ryan Small, Debbie Bull, Andrew Powers'
+location: Cafe Allegro
+time: 6pm
+---
+
+## Order of events:
+
+1. Determine roles
+2. Discuss role of the board
+3. Meetings
+4. Spring fling
+
+## Roles
+
+- President (Andrew Powers): calls meetings together
+- VP (Debbie Bull): calls meetings together if the President isn't available
+- Secretary (Sam Matthews): keep meeting notes in a public place
+- Treasurer (Ryan Small): does the money
+
+## Role of the board
+
+Lots of people do work to keep CUGOS running. How can we run the group more effectively, get people engaged/involved so not all of the planning falls on one/two/three people? Good to have a rotating board to make this mindset more apparent.
+
+The goal of the board is to grow the CUGOS membership and help those members become more invested in the organization through volunteer opportunities.
+
+## Meetings
+
+* Facilitator per meeting?
+* Can we appoint people to find talks for specific meetings?
+* Projector: Ryan Small is going to look into this - try and get something purchased soon. Something with HDMI **on** the projector.
+
+### Upcoming meeting
+
+Debbie will go over the meeting notes from this meeting! At the end of the meeting let's discuss the available spring fling committees and gauge interest.
+
+### Board meetings
+
+We'll do another meeting in between Jan & February meetings. Otherwise we'll stick to once a quarter.
+
+## Spring fling
+
+Started planning around this time. Let's get some overall ideas down now.
+
+* **Volunteers**: Let's get folks who are interested at the next meeting. Let's get the committees nailed down.
+* **Location**: Need to decide location. Do we want to persue a different space? What's involved? How about looking at an auditorium (better projector) and some breakout rooms. If it's not at UW, we'll likely have to pay. Possibly Seattle U - let's reach out to Clifford for contact to see pricing.
+* **Time**: potentially move to a weekend? Let's keep this in mind as we look at availability for locations. Let's stick with a single day.
+* **Afternoon sessions**: let's work on improving these this year. Last year we were a bit disorganized in the afternoon, with people burning out.
+* **Post Springfling die-off**: can we appoint a couple people to work on the meeting after the fling? How about making that a volunteer opportunity at the spring fling - focusing on the next meetings and generating new talks?
+
+## Next tasks
+
+* Andrew to get Debbie committee information from last year's Spring Fling
+* Andrew to write an email to Matt & Monica about spaces for the Spring Fling
+* Ryan to start researching projector - starting within the $500 - $800 range, HDMI, 1080p, brighter
+* Ryan to get in touch with Aaron about transferring accounts to Treasurer
+* Debbie speaking at next meeting
+* Sam to add slack notes to website for people to join - talk about at the meeting
+* Sam to post these notes online, and create a spot for future notes
+
+# Motions
+
+* Ryan Small makes motion to appoint Sam Matthews to Secretary. Andrew Powers seconded. Passes unanimously.
+* Andrew Powers makes motion to appoint Ryan Small as Treasurer. Debbie Bull seconded. Passes unanimously.
+* Sam Matthews makes motion to appoint Debbie Bull as Vice President. Debbie Bull seconded. Passes unanimously.
+* Debbie Bull makes motion to appoint Andrew Powers as President. Ryan Small Seconded. Passes unanimously.

--- a/notes/index.md
+++ b/notes/index.md
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect: /about
+---


### PR DESCRIPTION
This PR does two things:

1. Adds a new `notes` style post, used for board meeting notes
1. Changes the post URL structure for **all** posts. This shortens URLs, makes them less redundant, and generally cleans things up. The 404.html page has an updated script to search for URLs matching the date structure and attempting a redirect. If the redirect fails, the 404 page shows up.

        # previous
        cugos.org/meetings/2017/01/18/cugos_monthly
        # new
        cugos.org/meetings/2017-01-18/

cc @powersa 
