### PR TITLE
Updated add yourself link to point to February

### DIFF
--- a/meetings/_posts/2017-02-15-cugos_monthly.md
+++ b/meetings/_posts/2017-02-15-cugos_monthly.md
@@ -13,7 +13,7 @@ notes: It's the room with the elk in it.
 
 ## Agenda
 
-- **You!** Interested in helping with the website, elections, future event planning? Add yourself to [this meeting page on github](https://github.com/cugos/cugos.github.com/edit/master/meetings/_posts/2017-01-18-cugos_monthly.markdown) or hit us up at **hello@cugos.org**.
+- **You!** Interested in helping with the website, elections, future event planning? Add yourself to [this meeting page on github](https://github.com/cugos/cugos.github.com/edit/master/meetings/_posts/2017-02-15-cugos_monthly.markdown) or hit us up at **hello@cugos.org**.
 
 ## Wireless Info
 


### PR DESCRIPTION
Just happened to notice this on the way to making other edits to January's meeting page.