### PR TITLE
add speaker application link, small link fixes

### DIFF
--- a/2019-fall-fling/index.md
+++ b/2019-fall-fling/index.md
@@ -7,6 +7,7 @@ event_time: "8:30 AM - 4:30 PM"
 event_description: "The CUGOS Fall Fling is a full-day event centered around open source geography. This is a great way to learn about new mapping software, hear how companies are integrating location into their products, and get some hands-on experience with important tools like Leaflet, Turf.js, QGIS, and PostGIS. We welcome all students, professionals, map lovers, coders, and anyone with a passion for learning about spatial information. The Fall Fling is designed for anyone with an interest in maps and open source software."
 event_location: "Univ. of Washington, Seattle, WA. Paul G. Allen Center for Computer Science (CSE)"
 event_register-url: "https://docs.google.com/forms/d/e/1FAIpQLSc184HO6ZtIgZ28hPFS4oN0l8JP1BbCEAUVljTARj92ukJ6dA/viewform"
+event_submit-talk-url: "https://docs.google.com/forms/d/e/1FAIpQLSeSnQIMG-95JM2eL_E-dlG_f3ZI0M_S1l9vUvyMCUZbN3_xdA/viewform"
 markers:
   -
     name: Univ. of Washington, Seattle. Paul G. Allen Center for Computer Science (CSE)

--- a/_layouts/event-2019.html
+++ b/_layouts/event-2019.html
@@ -153,6 +153,7 @@ nav {
       <strong>When?</strong> {{ page.event_date }}, {{ page.event_time }}<br>
       <strong>Where?</strong> {{ page.event_location }}<br>
       <strong>How?</strong> <a class="spring-fling-register" href="{{ page.event_register-url }}">Sign up to be notified here!</a><br>
+      <strong>Speak!</strong> <a class="spring-fling-register" href="{{ page.event_submit-talk-url }}">Submit an application to give a talk or workshop!</a><br>
     </p>
   </div>
 </header>
@@ -169,7 +170,7 @@ nav {
 <section id="schedule" class="spring-fling-section">
   <div class="container">
     <span class="spring-fling-section-header">schedule</span>
-    <p>We're working on a great schedule for this year. Take a peek at the schedule from the <a href="/2017-spring-fling">2017 Spring Fling</a> to get a sense of what to expect. If you'd like to give a talk or think you know someone who would give a great talk feel free to reach out to <a href="">hello@cugos.org</a>.</p>
+    <p>We're working on a great schedule for this year. Take a peek at the schedule from the <a href="/2017-spring-fling">2017 Spring Fling</a> to get a sense of what to expect. If you'd like to give a talk or think you know someone who would give a great talk <a href="{{ page.event_submit-talk-url }}">submit an application here</a>.</p>
 
     {% for item in page.schedule %}
     <div class="sf-schedule-block cf {{ item.type }}">
@@ -211,7 +212,7 @@ nav {
       {% include event-sponsor.html sponsors=page.event_sponsors_comm title="Community Sponsors" color="text-bronze" %}
     {% endif %}
 
-    <p>Interested in sponsoring this event? Send us a message at <a href="">hello@cugos.org</a>.</p>
+    <p>Interested in sponsoring this event? Send us a message at <a href="mailto:hello@cugos.org">hello@cugos.org</a>.</p>
 
   </div>
 </section>
@@ -219,7 +220,7 @@ nav {
 <section id="volunteer" class="spring-fling-section">
   <div class="container">
     <span class="spring-fling-section-header">volunteer</span>
-    <p>We are a small team of CUGOS regulars focused on putting together a great event for the broader geospatial community. Interested in helping out? Sign up <a href=""https://docs.google.com/forms/d/e/1FAIpQLSc184HO6ZtIgZ28hPFS4oN0l8JP1BbCEAUVljTARj92ukJ6dA/viewform>here.</a></p>
+    <p>We are a small team of CUGOS regulars focused on putting together a great event for the broader geospatial community. Interested in helping out? Sign up <a href="https://docs.google.com/forms/d/e/1FAIpQLSc184HO6ZtIgZ28hPFS4oN0l8JP1BbCEAUVljTARj92ukJ6dA/viewform">here.</a></p>
   </div>
 </section>
 


### PR DESCRIPTION
This adds a link to the speaker application form (https://docs.google.com/forms/d/e/1FAIpQLSeSnQIMG-95JM2eL_E-dlG_f3ZI0M_S1l9vUvyMCUZbN3_xdA/viewform).

Also makes a couple other little link fixes.

![Screen Shot 2019-07-02 at 4 05 13 PM](https://user-images.githubusercontent.com/164214/60552331-3445a700-9ce3-11e9-9ba8-e361e23ff966.png)
