### PR TITLE
Add link to self-add to Slack

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ We're a group of developers, GIS specialists, designers, and geographers all gat
 
 We [meet regularly](/meetings) on the third wednesday of every month and irregularly on Thursdays at different locations. If you're interested in participating in our community, you can find us through the following channels:
 
-* [Slack Group](https://cugos.slack.com) - for daily communication and updates. Send an email to <em>hello@cugos.org</em> for an invitation.
+* [Slack Group](https://cugos.slack.com) - for daily communication and updates. [Request to add yourself](https://join.slack.com/t/cugos/shared_invite/enQtNjcwMjIyNDg3MjY4LWM2NzY1NjAwZmNmZGU3ZjFkYjNhZjdjYjY2NWI4NGJkY2I4OGE2MDJjZTRmNDkwMjM2MTRiZGIyMThkMzNiYWU) or email <em>hello@cugos.org</em> for an invitation.
 * [Google Group](https://groups.google.com/forum/#!forum/cugos) - more substantial posts and tid-bits about projects, conference updates, sidecar meetings, and job postings. Send an email to <em>hello@cugos.org</em> for an invitation.
 * IRC - CUGOS has its own IRC channel hosted on [Freenode](https://freenode.net/). You can connect to our channel <strong>#cugos</strong>. If you're new to IRC, there's a [neat web client](http://webchat.freenode.net/) so you don't have to download any software. No invitation necessary.
 


### PR DESCRIPTION
Per https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace#share-an-invite-link, this should work for up to 2000 members before it has to be re-created.