### PR TITLE
Fix static images on /meetings page

### DIFF
--- a/_layouts/meetings.html
+++ b/_layouts/meetings.html
@@ -16,14 +16,14 @@ layout: default
 
     <p>If you're interested in speaking at CUGOS, feel free to drop us an email at <em>hello@cugos.org</em> or find us on IRC - <strong>freenode</strong> network, <strong>#cugos</strong> channel.</p>
   </div>
-  
+
   {% include next-meeting.html %}
 
   <h2>All Meetings</h2>
   <ul id="meetings-list" class="cf">
     {% for meeting in site.categories.meetings %}
       <li><a href="{{ meeting.url }}">
-        <img src="http://api.tiles.mapbox.com/v4/cugos.ma6ck6l4/pin-m-commercial+f44({{ meeting.lng }},{{ meeting.lat }},18)/{{ meeting.lng }},{{ meeting.lat }},14/150x150.png?access_token=pk.eyJ1IjoiY3Vnb3MiLCJhIjoidGNnSlBNTSJ9.qPHDxAemDindkSskKNv90g">
+        <img src="https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/pin-s+555555({{ meeting.lng | default: 0.0 }},{{ meeting.lat | default: 0.0 }})/{{ meeting.lng | default: 0.0 }},{{ meeting.lat | default: 0.0 }},12,0/150x150?access_token=pk.eyJ1IjoiY3Vnb3MiLCJhIjoidGNnSlBNTSJ9.qPHDxAemDindkSskKNv90g">
         <p class="meeting-list-info"><span class="meeting-list-date">{{ meeting.date | date: "%m/%d/%Y" }}</span><br>
         Host: {{ meeting.location }}<br>
         <span class="meeting-list-address">Address: {{ meeting.address }}</span></p>


### PR DESCRIPTION
The meetings page was using an old Mapbox endpoint for static images, and was receiving HTTP 410 responses since they have since been deprecated. This updates the URL to point to the /styles/v1 endpoint to retrieve a static image.

![Screen Shot 2022-04-22 at 11 24 19 AM](https://user-images.githubusercontent.com/1943001/164773118-7b56432c-2418-4325-9272-84a00436fa9d.png)

