### PR TITLE
Add may 2023 meeting

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,8 +1,6 @@
 ---
 layout: home
 title: Home
-alert_text: "The 2023 Spring Fling is on April 21st - Register Now!"
-alert_url: /2023-spring-fling
 extra_js: /static/js/feed.js
 ---
 

--- a/meetings/_posts/2023-05-17-cugos_monthly.md
+++ b/meetings/_posts/2023-05-17-cugos_monthly.md
@@ -1,0 +1,24 @@
+---
+layout: meeting
+title: May 17th 2023
+location: University of Washington, TBD
+address: TBD
+time: 6:00pm-7:30pm
+excerpt: May 17, 2023 CUGOS Monthly Meeting
+lat: 47.653807
+lng: -122.307835
+category: meetings
+notes: We will adjourn to the College Inn Pub for a happy hour after the meeting!
+---
+
+**Anyone** is invited to share (their own or news about any interesting) small or large geospatial projects. As always any geo-questions are encouraged and will gladly be discussed within the group.
+
+**[@you](http://cugos.org/people/)** Introduce yourself! Or re-introduce yourself! Please tell us about something cool you are working on, playing with, or otherwise inspires or puzzles you. [Add yourself here.](https://github.com/cugos/cugos.github.com/blob/master/meetings/_posts/2023-05-17-cugos_monthly.md) or reach out to us hello@cugos.org
+
+## Reminder 
+about some other cool open source and/or geo-related meetups in the area:
+
+[OpenStreetMap Seattle](https://www.meetup.com/OpenStreetMap-Seattle/)  
+[Puget Sound QGIS Users](https://www.meetup.com/Puget-Sound-QGIS-Users-Group/)  
+[Seattle Postgres Users](https://www.meetup.com/Seattle-Postgres/)  
+[Maptime Seattle](https://www.meetup.com/MaptimeSEA/)


### PR DESCRIPTION
Removes spring fling alert banner from the homepage (still leaving the header link, though) and adding a page for the May meeting.