### PR TITLE
Feature/past flings

### DIFF
--- a/2025-fall-fling/index.md
+++ b/2025-fall-fling/index.md
@@ -1,6 +1,6 @@
 ---
 layout: event-2025
-weight: 1
+weight: ~
 title_small: "2025 Fall Fling"
 title: "CUGOS 2025 Fall Fling"
 event_description: |

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,16 @@ future: true
 markdown: kramdown
 highlighter: rouge
 permalink: /:categories/:year-:month-:day/
+flings:
+  - year: 2025
+    url: /2025-fall-fling/
+  - year: 2023
+    url: /2023-spring-fling/
+  - year: 2019
+    url: /2019-fall-fling/
+  - year: 2017
+    url: /2017-spring-fling/
+  - year: 2016
+    url: /2016-spring-fling/
+  - year: 2015
+    url: /2015-spring-fling/

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -17,7 +17,7 @@
         {% comment %} Additionally, if weight = 5, add the past flings dropdown menu {% endcomment %}
         {% if weight == 5 %}
           <li class="dropdown {% if page.url contains 'fling' %}active{% endif %}">
-            <a href="/2025-fall-fling/">Flings <i class="fa fa-caret-down"></i></a>
+            <a>Flings <i class="fa fa-caret-down"></i></a>
             <ul class="dropdown-menu">
               {% for fling in site.flings %}
               <li><a href="{{ fling.url }}">{{ fling.year }}</a></li>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,26 +3,30 @@
     <a id="brand-logo" href="/">CUGOS {% include cugos-svg-logo.html %}</a>
     <button id="menu-expand"><i class="fa fa-bars"></i></button>
     <ul id="menu">
-      {% for weight in (0..10) %}{% if weight == 5 %}
-      <li class="dropdown {% if page.url contains 'fling' %}active{% endif %}">
-        <a href="/2025-fall-fling/">Flings <i class="fa fa-caret-down"></i></a>
-        <ul class="dropdown-menu">
-          {% for fling in site.flings %}
-          <li><a href="{{ fling.url }}">{{ fling.year }}</a></li>
-          {% endfor %}
-        </ul>
-      </li>
-      {% endif %}{% for p in site.pages %}{% if p.weight == weight %}
-      <li class="{% if p.url == page.url %}active{% endif %} {{ p.nav_class }}">
-        <a href="{{ p.url }}">
-          {% if p.title_small %}
-            {{ p.title_small }}
-          {% else %}
-            {{ p.title }}
+      {% for weight in (0..10) %}
+        {% for p in site.pages %}
+          {% if p.weight == weight %}
+            <li class="{% if p.url == page.url %}active{% endif %} {{ p.nav_class }}">
+              <a href="{{ p.url }}">
+                {% if p.title_small %}{{ p.title_small }}{% else %}{{ p.title }}{% endif %}
+              </a>
+            </li>
           {% endif %}
-        </a>
-      </li>
-      {% endif %}{% endfor %}{% endfor %}
+        {% endfor %}{% comment %} End page loop {% endcomment %}
+
+        {% comment %} Additionally, if weight = 5, add the past flings dropdown menu {% endcomment %}
+        {% if weight == 5 %}
+          <li class="dropdown {% if page.url contains 'fling' %}active{% endif %}">
+            <a href="/2025-fall-fling/">Flings <i class="fa fa-caret-down"></i></a>
+            <ul class="dropdown-menu">
+              {% for fling in site.flings %}
+              <li><a href="{{ fling.url }}">{{ fling.year }}</a></li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% endif %} {% comment %} End of fling loop {% endcomment %}
+
+      {% endfor %} {% comment %} End weight loop {% endcomment %}
     </ul>
   </div>
 </nav>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,7 +3,16 @@
     <a id="brand-logo" href="/">CUGOS {% include cugos-svg-logo.html %}</a>
     <button id="menu-expand"><i class="fa fa-bars"></i></button>
     <ul id="menu">
-      {% for weight in (0..10) %}{% for p in site.pages %}{% if p.weight == weight %}
+      {% for weight in (0..10) %}{% if weight == 5 %}
+      <li class="dropdown {% if page.url contains 'fling' %}active{% endif %}">
+        <a href="/2025-fall-fling/">Flings <i class="fa fa-caret-down"></i></a>
+        <ul class="dropdown-menu">
+          {% for fling in site.flings %}
+          <li><a href="{{ fling.url }}">{{ fling.year }}</a></li>
+          {% endfor %}
+        </ul>
+      </li>
+      {% endif %}{% for p in site.pages %}{% if p.weight == weight %}
       <li class="{% if p.url == page.url %}active{% endif %} {{ p.nav_class }}">
         <a href="{{ p.url }}">
           {% if p.title_small %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,7 +16,8 @@
 
         {% comment %} Additionally, if weight = 5, add the past flings dropdown menu {% endcomment %}
         {% if weight == 5 %}
-          <li class="dropdown {% if page.url contains 'fling' %}active{% endif %}">
+          {% assign fling_urls = site.flings | map: 'url' %}
+          <li class="dropdown {% if fling_urls contains page.url %}active{% endif %}">
             <a>Flings <i class="fa fa-caret-down"></i></a>
             <ul class="dropdown-menu">
               {% for fling in site.flings %}

--- a/about/index.md
+++ b/about/index.md
@@ -1,7 +1,7 @@
 ---
 layout: about
 title: About
-weight: 7
+weight: 2
 sidebar:
   - contact
   - coc

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Blog
-weight: 4
+weight: 6
 sidebar:
   - about
   - coc

--- a/people/index.html
+++ b/people/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: People
-weight: 6
+weight: 3
 extra_js:
   - /static/js/people.js
 use_leaflet: true

--- a/projects/index.md
+++ b/projects/index.md
@@ -1,13 +1,13 @@
 ---
 layout: projects
 title: "Projects"
-weight: 3
+weight: 4
 description: Over the years, CUGOS has put together a few community projects. Check them out here!
 
 projects:
  -
     title: CUGOS.org
-    description: This website! 
+    description: This website!
     url: http://cugos.org/
     github: https://github.com/cugos/cugos.github.com
  -

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -219,7 +219,7 @@ nav {
 #menu li:not(.dropdown):hover a {
   border-bottom: 2px solid white;
 }
-#menu li.active a {
+#menu li.active > a {
   font-weight:900;
 }
 

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -242,7 +242,8 @@ nav {
   #menu {
     margin:0;
     padding:0;
-    display: inline-block;
+    display: flex;
+    align-items: center;
     float: right;
   }
   #menu-expand {

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -264,6 +264,49 @@ nav {
   }
 }
 
+/* DROPDOWN */
+#menu .dropdown-menu {
+  display: block;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+#menu .dropdown-menu li {
+  padding-left: 1.6em;
+}
+@media screen and (min-width:41em) {
+  #menu li.dropdown {
+    position: relative;
+  }
+  #menu .dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background-color: #3f75a2;
+    padding: 0.4em 0;
+    min-width: 7em;
+    z-index: 100;
+  }
+  #menu li.dropdown:hover .dropdown-menu {
+    display: block;
+  }
+  #menu .dropdown-menu li {
+    display: block;
+    padding: 0 0.8em;
+  }
+  #menu .dropdown-menu li a {
+    display: block;
+    white-space: nowrap;
+    border-bottom: none;
+    text-align: center;
+  }
+  #menu .dropdown-menu li:hover a {
+    border-bottom: none;
+    font-weight: 900;
+  }
+}
+
 
 /* HOMEPAGE */
 .home .cugos-svg {

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -216,7 +216,7 @@ nav {
   padding:.6em 0;
   border-bottom: 2px solid transparent;
 }
-#menu li:hover a {
+#menu li:not(.dropdown):hover a {
   border-bottom: 2px solid white;
 }
 #menu li.active a {


### PR DESCRIPTION
This PR addresses Issue #274.

Changes:

1. **Added all past Fling pages to a navbar dropdown list.** This is mostly an update to `_includes/nav.html` with some new CSS to style the dropdown. To make this a "Jekyll-y" update, fling titles (years), order, and paths are stored in the `_config.yml` metadata. Past flings are sorted in reverse chronological order. 
2. Removed the 2025 Fall Fling link from the header—it's now listed as the first dropdown item
3. Adding this header item revealed some brittle CSS styling for navbar items: I fixed this so they're consistently vertically centered.
4. Reordered the navbar items. "Blog" is now at the end, pending a possible drop—see Issue #421.

You can preview this change by serving the PR locally:
```
gh pr checkout 423
jekyll serve
```

Here are some example screenshots:

_Front page:_

<img width="1178" height="194" alt="image" src="https://github.com/user-attachments/assets/be3b6fd7-ee40-4406-abaf-91aafda5d221" />

_Front page, dropdown expanded, mouse hovering over "2025":_

<img width="1244" height="476" alt="image" src="https://github.com/user-attachments/assets/a28580e6-8b58-4804-bd0a-35468a6204f7" />

_Narrow viewport, nav menu expanded:_

<img width="635" height="741" alt="image" src="https://github.com/user-attachments/assets/ad1e9063-455b-48c6-a93e-0141f7275399" />

_On a fling page:_

<img width="1397" height="750" alt="image" src="https://github.com/user-attachments/assets/f1fcf5c6-ba46-46d2-b545-fca53cae09b1" />