### PR TITLE
Add contributing guidelines and update README structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to the CUGOS Website
+
+The CUGOS website is built on [Jekyll](https://jekyllrb.com/) and hosted via GitHub Pages. All contributions are welcome. Please first review our [Code of Conduct](https://cugos.org/code-of-conduct). If you have questions and want faster and more reliable responses, [join us on Slack](https://join.slack.com/t/cugos/shared_invite/enQtNjcwMjIyNDg3MjY4LWM2NzY1NjAwZmNmZGU3ZjFkYjNhZjdjYjY2NWI4NGJkY2I4OGE2MDJjZTRmNDkwMjM2MTRiZGIyMThkMzNiYWU).
+
+## Site Structure
+
+The site uses Jekyll's post system to manage content. Most content lives in dated Markdown files organized into subdirectories:
+
+| Directory | Content |
+| --------- | ------- |
+| `meetings/_posts/` | Monthly meeting agendas |
+| `notes/_posts/` | Meeting notes and summaries |
+| `blog/_posts/` | Blog entries |
+| `people/_posts/` | Member profiles |
+
+New content follows the naming convention `YYYY-MM-DD-description.md` (or `.markdown` for older files). To add a new page, copy the most recent file in the relevant directory and update the content.
+
+## Picking Up an Issue
+
+If you'd like to work on an open issue, assign yourself. This lets others know it's being handled. There's no formal assignment process. If something is sitting unassigned and you have the time, go for it.
+
+Each time you work on the issue, leave a comment so others know it is active. You can also ask questions or explain if you are stuck; someone else may be able to offer suggestions.
+
+If you end up no longer wanting to or not being able to fix the issue, please leave a comment with anything you learned and unassign yourself so someone else can pick it up.
+
+If you want to work on an issue that is already assigned, leave a comment saying you would like to contribute. If someone reaches out to you this way, please respond within 48 hours. It's up to the original assignee whether to accept help. You can always thank someone who offers and suggest they review your PR instead, but you're welcome to accept other types of help too.
+
+If an issue is assigned but has no updates or PRs within a month, it is assumed to be inactive. We will add an `inactive` label and ping the assignee; if there is no response within a week, the issue becomes open again.
+
+## Contributing an Idea or Bug Report
+
+On the Issues tab, press **New Issue** to open an issue. It's a lightweight way to start a conversation and anyone should feel free to do this.
+
+For small, self-contained changes you know how to fix (fixing a broken link, updating an event page, correcting a typo), just open a PR. No issue needed.
+
+For anything structural (a new feature, a layout change, a refactor), open an issue first to describe the problem and proposed approach. This gives other members a chance to weigh in before work begins and avoids duplicating effort.
+
+## Local Setup
+
+You can skip this step when making text or Markdown changes only, and instead follow the instructions in the README for editing via GitHub's editor.
+
+For all other changes, please clone the repo, develop, and test locally before submitting a PR.
+
+```bash
+git clone https://github.com/YOUR-USERNAME/cugos.github.com.git
+cd cugos.github.com
+gem install jekyll
+jekyll serve
+```
+
+The site will be available in your browser at `localhost:4000`.
+
+## Opening a Pull Request
+
+1. Fork or branch from `main`
+2. Make your changes and test locally
+3. Open a pull request with a brief description of what changed and why
+4. Request a review from another CUGOS member (or several)
+
+If you don't know who to assign, it's ok to leave it blank, but if you can please ping in the [CUGOS Slack](https://cugos.slack.com) so someone can get to it quickly.
+
+All PRs to `main` require at least one approval before merging. The goal is a second set of eyes, not a formal gate.
+
+## Reviewing a PR
+
+Anyone in the CUGOS community is welcome to review a PR. A good review:
+
+- Confirms the change works as described
+- Flags anything that looks broken or inconsistent with the rest of the site
+- Is constructive: suggest alternatives rather than just pointing out problems
+
+If a PR looks good to you, approve it. If you have questions or concerns, leave a comment. Keep feedback focused on the change, not the contributor.
+
+## Handling Review Feedback
+
+If you receive feedback, respond to each comment, either with a code change or an explanation of why you've taken a different approach. Once all comments are resolved, re-request review. If feedback sits unaddressed, a reviewer may close the PR with a note that it can be reopened when ready.
+
+## Getting Direct Push Access
+
+If you'd like to contribute regularly without forking, [join the CUGOS Slack](https://join.slack.com/t/cugos/shared_invite/enQtNjcwMjIyNDg3MjY4LWM2NzY1NjAwZmNmZGU3ZjFkYjNhZjdjYjY2NWI4NGJkY2I4OGE2MDJjZTRmNDkwMjM2MTRiZGIyMThkMzNiYWU) and reach out. Someone will add you to the CUGOS GitHub organization.

--- a/README.md
+++ b/README.md
@@ -1,43 +1,30 @@
-cugos.github.com
-================
+# cugos.github.com
 
 The CUGOS website source. *Your home away from home.*
 
-## Contributing
+## Community
 
-**Editing Content**   
-All of our meeting updates and blog posts are curated through these files. Check out [the wiki](https://github.com/cugos/cugos.github.com/wiki/Editing-The-Website) for details on how the website works and how to edit or add content.
+Join us on [Slack](https://join.slack.com/t/cugos/shared_invite/enQtNjcwMjIyNDg3MjY4LWM2NzY1NjAwZmNmZGU3ZjFkYjNhZjdjYjY2NWI4NGJkY2I4OGE2MDJjZTRmNDkwMjM2MTRiZGIyMThkMzNiYWU) for questions, discussion, and updates.
 
-**Site Development**   
-The site is built on [Jekyll](http://jekyllrb.com/) and [Github Pages](https://pages.github.com/), while the template files, [JavaScript](https://github.com/cugos/cugos.github.com/tree/master/js), and [CSS](https://github.com/cugos/cugos.github.com/blob/master/css/site.css) are all hand-rolled by the members of CUGOS.
+## Adding Yourself to a Meeting Agenda
 
-If you're interested in helping out with the development of the site, please feel free to fork and edit locally before creating a pull-request. The following steps assume you have [Jekyll 2.0 installed](http://jekyllrb.com/docs/installation/) (including jekyll-sitemap, perhaps by: *gem install jekyll-sitemap*) and running properly on your machine. *Note: If you'd like edit access to this repository to skip the forking and pulling process, send an email to **hello@cugos.org** and we'll get you set up!*
+Meeting agendas live in [`meetings/_posts/`](https://github.com/cugos/cugos.github.com/tree/main/meetings/_posts). Files are named `YYYY-MM-DD-meeting.md` and sorted by date, the most recent is at the bottom.
 
-1. **[Fork](https://github.com/cugos/cugos.github.com/fork)** this repository into your own working repo
-1. **Clone** your newly created repository into your local machine
-1. **Navigate** into the newly created `cugos.github.com` directory.
-1. **Run jekyll**, which will serve the site at `localhost:4000` and watch for changes.
-1. **Commit** and **push** your changes to your forked repository
-1. Create a **pull request** to merge your changes into the cugos master repository!
-1. Have a beer!
+1. Open the current month's meeting file and click the pencil (edit) icon
+2. Add your name, topic, or agenda item using [Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
+3. Add a short commit message describing your change and click **Commit changes**
 
-Command line steps after forking the repository:
+Click **Commit changes...** and GitHub will walk you through how to open a pull request.
 
-```
-git clone https://github.com/YOUR-USERNAME/cugos.github.com.git
-cd cugos.github.com
-jekyll serve --watch
-```
+To join the CUGOS GitHub organization and skip the fork step in the future, reach out on Slack or email [hello@cugos.org](mailto:hello@cugos.org).
 
-*...make changes...*   
+## Site Development
 
-```
-git add --all
-git commit -m 'YOUR COMMIT MESSAGE'
-git push origin master
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and the full contribution workflow.
 
-*Create a pull request between your repository and this repository.*
+## Code of Conduct
+
+All contributors are expected to follow the [CUGOS Code of Conduct](https://cugos.org/code-of-conduct).
 
 ## Attribution
 
@@ -46,5 +33,3 @@ git push origin master
 * Jekyll
 * jQuery
 * [Homepage Mountains](https://flic.kr/p/5UJi5S) photo by [Jeff P](https://www.flickr.com/photos/jeffpang/) | CC Attribution 2.0 Generic[*](https://creativecommons.org/licenses/by/2.0/)
-
-:+1:


### PR DESCRIPTION
Closes #425

Wrote new a new CONTRIBUTING.md and revised the README.md. Once merged, we should be able to delete/deprecate the Wiki.

Most of this was lifted from existing sources within the repo, with the exception of the "Picking Up Issues" section of CONTRIBUTING.md.

I think the only other liberty I took: directing people to reach out on Slack instead of to hello@cugos.org (only because I do not know who is maintaining this, or how much... happy to change)

Review checklist:
- [x] Verify with @njhenry that linking to the existing Code of Conduct makes sense (rather than creating a new one)
- [x] Tighten up PR approval / merge requirements (with possible exemption for meeting agendas)
- [x] Audit and update security more generally
- [ ] Incorporate any other suggestions or discussion points