### PR TITLE
Add September 16th, 2026 meeting details

### DIFF
--- a/meetings/_posts/2026-09-16-cugos_monthly.md
+++ b/meetings/_posts/2026-09-16-cugos_monthly.md
@@ -1,0 +1,14 @@
+---
+layout: meeting
+title: September 16th, 2026
+location: Bloedel Hall Room 292, University of Washington
+address: Seattle, WA 98195
+time: 6:00pm-7:30pm
+excerpt: September 16th, 2026 CUGOS Monthly Meeting
+lat: 47.65137
+lng: -122.30795
+category: meetings
+notes: The building is locked after 5pm. Someone will be there 5-10 minutes until 6pm to let us in at the entrance near the bike shelter at the northwest corner of the building. If you see nobody around and can't access, ping the CUGOS Slack to be let in. We will adjourn to a nearby pub for a happy hour after the meeting!
+---
+
+**[@you](/people/)** Introduce yourself! Or re-introduce yourself! Tell us about something cool you are working on, playing with, or otherwise inspires or puzzles you. To get on the agenda, you can [edit this page](https://github.com/cugos/cugos.github.com?tab=readme-ov-file#contributing), or send us an email: [hello@cugos.org](mailto:hello@cugos.org)


### PR DESCRIPTION
Adds the next CUGOS monthly meeting post for September 16, 2026 (third Wednesday), with placeholder agenda—mainly so that the "next meeting" listed on the front page is accurate.